### PR TITLE
Compile as shared libraries

### DIFF
--- a/cleedpy/cleed/CMakeLists.txt
+++ b/cleedpy/cleed/CMakeLists.txt
@@ -5,6 +5,10 @@ project(cleed VERSION 1.0 LANGUAGES C)
 set(CMAKE_C_STANDARD 90)
 set(CMAKE_C_STANDARD_REQUIRED True)
 
+# Set the output directories
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 # Workaround for Apple Clang
 # Disables the warning "implicit declaration of function '...' is invalid in C99"
 if(APPLE AND "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang")

--- a/cleedpy/cleed/src/CMakeLists.txt
+++ b/cleedpy/cleed/src/CMakeLists.txt
@@ -13,4 +13,4 @@ list(REMOVE_ITEM CLEED_SRC
 add_library(cleed SHARED ${CLEED_SRC})
 
 # Link libmat
-target_link_libraries(cleed libmat m dl)
+target_link_libraries(cleed mat m dl)

--- a/cleedpy/cleed/src/CMakeLists.txt
+++ b/cleedpy/cleed/src/CMakeLists.txt
@@ -4,7 +4,7 @@ add_subdirectory(libmat)
 # Compile cleed source files
 file(GLOB CLEED_SRC "*.c")
 
-# Remove a few src files that contains duplicated symbols
+# Remove a few src files that contain duplicated symbols
 list(REMOVE_ITEM CLEED_SRC
     "${CMAKE_CURRENT_SOURCE_DIR}/linpphase.c"
     "${CMAKE_CURRENT_SOURCE_DIR}/lpcmktlnd_read.c"

--- a/cleedpy/cleed/src/CMakeLists.txt
+++ b/cleedpy/cleed/src/CMakeLists.txt
@@ -3,7 +3,14 @@ add_subdirectory(libmat)
 
 # Compile cleed source files
 file(GLOB CLEED_SRC "*.c")
-add_library(cleed ${CLEED_SRC})
+
+# Remove a few src files that contains duplicated symbols
+list(REMOVE_ITEM CLEED_SRC
+    "${CMAKE_CURRENT_SOURCE_DIR}/linpphase.c"
+    "${CMAKE_CURRENT_SOURCE_DIR}/lpcmktlnd_read.c"
+)
+
+add_library(cleed SHARED ${CLEED_SRC})
 
 # Link libmat
 target_link_libraries(cleed libmat m dl)

--- a/cleedpy/cleed/src/libmat/CMakeLists.txt
+++ b/cleedpy/cleed/src/libmat/CMakeLists.txt
@@ -5,7 +5,7 @@ set(BLA_VENDOR OpenBLAS)
 file(GLOB LIBMAT_SOURCES "mat*.c")
 
 # Define the library from the collected source files
-add_library(libmat ${LIBMAT_SOURCES})
+add_library(libmat STATIC ${LIBMAT_SOURCES})
 
 # Find BLAS/LAPACK
 find_package(BLAS REQUIRED)

--- a/cleedpy/cleed/src/libmat/CMakeLists.txt
+++ b/cleedpy/cleed/src/libmat/CMakeLists.txt
@@ -5,7 +5,7 @@ set(BLA_VENDOR OpenBLAS)
 file(GLOB LIBMAT_SOURCES "mat*.c")
 
 # Define the library from the collected source files
-add_library(mat ${LIBMAT_SOURCES})
+add_library(mat SHARED ${LIBMAT_SOURCES})
 
 # Find BLAS/LAPACK
 find_package(BLAS REQUIRED)

--- a/cleedpy/cleed/src/libmat/CMakeLists.txt
+++ b/cleedpy/cleed/src/libmat/CMakeLists.txt
@@ -5,7 +5,7 @@ set(BLA_VENDOR OpenBLAS)
 file(GLOB LIBMAT_SOURCES "mat*.c")
 
 # Define the library from the collected source files
-add_library(libmat STATIC ${LIBMAT_SOURCES})
+add_library(mat ${LIBMAT_SOURCES})
 
 # Find BLAS/LAPACK
 find_package(BLAS REQUIRED)
@@ -18,4 +18,4 @@ if(BLAS_HEADER)
 endif()
 
 # Link libmat with BLAS/LAPACK
-target_link_libraries(libmat ${BLAS_LIBRARIES})
+target_link_libraries(mat ${BLAS_LIBRARIES})


### PR DESCRIPTION
Adjust CMake to output libraries in the `build/lib` subdirectory and produce dynamic libraries. `libcleed` will be needed by the Python interface.