### PR TITLE
Fix local build & install

### DIFF
--- a/cleedpy/cleed/src/CMakeLists.txt
+++ b/cleedpy/cleed/src/CMakeLists.txt
@@ -15,10 +15,26 @@ add_library(cleed SHARED ${CLEED_SRC})
 # Link libmat
 target_link_libraries(cleed mat m dl)
 
+# This is needed to tell the linker where to find `libmat`
+# `libcleed` depends on it and setting RPATH allows us
+# to resolve the correct path at runtime
+# @loader_path and $ORIGIN point to the folder of the currently loaded shared library
+if(APPLE)
+    set_target_properties(cleed PROPERTIES
+        INSTALL_RPATH "@loader_path"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+elseif(UNIX)
+    set_target_properties(cleed PROPERTIES
+        INSTALL_RPATH "$ORIGIN"
+        BUILD_WITH_INSTALL_RPATH TRUE
+    )
+endif()
+
 # Install the cleed library into the Python package
-# scikit-build-core will place this in the wheel at cleedpy/cleed/lib/
+# Use SKBUILD_PROJECT_NAME variable provided by scikit-build-core
 install(TARGETS cleed
-    LIBRARY DESTINATION cleed/lib
-    RUNTIME DESTINATION cleed/bin
+    LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME}
+    RUNTIME DESTINATION ${SKBUILD_PROJECT_NAME}
     COMPONENT cleed
 )

--- a/cleedpy/cleed/src/libmat/CMakeLists.txt
+++ b/cleedpy/cleed/src/libmat/CMakeLists.txt
@@ -69,7 +69,7 @@ message(STATUS "BLAS libraries: ${BLAS_LIBRARIES}")
 
 # Install the mat library into the Python package
 install(TARGETS mat
-    LIBRARY DESTINATION cleed/lib
-    RUNTIME DESTINATION cleed/bin
+    LIBRARY DESTINATION ${SKBUILD_PROJECT_NAME}
+    RUNTIME DESTINATION ${SKBUILD_PROJECT_NAME}
     COMPONENT cleed
 )

--- a/cleedpy/interface/cleed.py
+++ b/cleedpy/interface/cleed.py
@@ -255,10 +255,10 @@ def get_cleed_lib() -> CDLL:
 
     # Neither location worked
     raise FileNotFoundError(
-            "Could not find or load libcleed library. Tried:\n"
-            + f"  - {installed_path} (installed)\n"
-            + f"  - {dev_path} (development)\n"
-            + "Make sure the package is properly built."
+        "Could not find or load libcleed library. Tried:\n"
+        + f"  - {installed_path} (installed)\n"
+        + f"  - {dev_path} (development)\n"
+        + "Make sure the package is properly built."
     )
 
 

--- a/cleedpy/interface/cleed.py
+++ b/cleedpy/interface/cleed.py
@@ -255,12 +255,10 @@ def get_cleed_lib() -> CDLL:
 
     # Neither location worked
     raise FileNotFoundError(
-        (
             "Could not find or load libcleed library. Tried:\n"
             + f"  - {installed_path} (installed)\n"
             + f"  - {dev_path} (development)\n"
             + "Make sure the package is properly built."
-        )
     )
 
 

--- a/cleedpy/interface/cleed.py
+++ b/cleedpy/interface/cleed.py
@@ -214,7 +214,7 @@ def generate_crystal_structure(inp: AtomParametersVariants) -> Crystal:
 
 
 def get_cleed_lib() -> CDLL:
-    lib_path = pl.Path(__file__).parent.parent / "cleed" / "lib"
+    lib_path = pl.Path(__file__).parent.parent
 
     lib_exts = {
         "Windows": ".dll",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ dev = [
   "pytest-cov==4.1.0",
 ]
 
+[build-system]
+requires = ["scikit-build-core>=0.10"]
+build-backend = "scikit_build_core.build"
+
 [tool.bumpver]
 current_version = "v0.1.4"
 version_pattern = "vMAJOR.MINOR.PATCH[PYTAGNUM]"
@@ -54,14 +58,8 @@ push = true
 
 [tool.bumpver.file_patterns]
 "cleedpy/version.py" = [
-    '__version__ = "{pep440_version}"',
+  '__version__ = "{pep440_version}"',
 ]
-
-
-
-[build-system]
-requires = ["scikit-build-core>=0.10"]
-build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]
 # CMake source directory (where CMakeLists.txt is located)
@@ -72,8 +70,6 @@ cmake.version = ">=3.15"
 build.verbose = true
 # Wheel build configuration
 wheel.packages = ["cleedpy"]
-# Install compiled libraries into the cleedpy package
-install.components = ["cleed"]
 
 # Dynamic version from Python module
 [tool.scikit-build.metadata.version]


### PR DESCRIPTION
Fixes #70 

- Correctly set install paths via scikit-build variable `SKBUILD_PROJECT_NAME`
- `[install.components]` was preventing CMake from installing the library files
- Use RPATH to resolve `libmat` when loading `libcleed`